### PR TITLE
fix(cb2-7861): resourceKey change and full, multiple security group sync 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18350,9 +18350,9 @@
       "dev": true
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+      "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
       "dev": true,
       "peer": true,
       "dependencies": {

--- a/src/aad/IMemberDetails.ts
+++ b/src/aad/IMemberDetails.ts
@@ -1,0 +1,25 @@
+export default interface IMemberDetails {
+  /** The type this member details object, such as '#microsoft.graph.user'.
+   * From the docs:
+   * A group can have users, organizational contacts, devices, service principals and other groups as members
+   */
+  '@odata.type': MemberType | string;
+
+  /** Unique identifier */
+  id: string;
+
+  businessPhones: string[] | null;
+  displayName: string | null;
+  givenName: string | null;
+  jobTitle: string | null;
+  mail: string | null;
+  mobilePhone: string | null;
+  officeLocation: string | null;
+  preferredLanguage: string | null;
+  surname: string | null;
+  userPrincipalName: string | null;
+}
+
+export enum MemberType {
+  User = '#microsoft.graph.user',
+}

--- a/src/aad/MemberDetails.ts
+++ b/src/aad/MemberDetails.ts
@@ -1,7 +1,0 @@
-interface MemberDetails {
-  displayName: string;
-  userPrincipalName: string;
-  staffId: string | null;
-}
-
-export default MemberDetails;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,6 +2,8 @@ export default {
   aad: {
     baseUrl: process.env.AAD_BASE_URL || 'https://graph.microsoft.com/',
     groupId: process.env.AAD_TESTER_GROUP_ID || '',
+    membersToRequest: process.env.AAD_TESTER_GROUP_MEMBERS_TO_REQUEST || 999,
+    filterGroupToUsersOnly: process.env.AAD_TESTER_GROUP_USERS_ONLY || true,
   },
   aws: {
     Secret: process.env.AAD_CLIENT_SECRET_NAME || '',

--- a/src/dynamo/IDynamoRecord.ts
+++ b/src/dynamo/IDynamoRecord.ts
@@ -1,5 +1,20 @@
 export default interface IDynamoRecord {
-  name: string;
-  email: string;
-  staffId: string | null;
+  /** The reference data resource type - for Testers this alway ResourceType.User */
+  resourceType: string;
+
+  /** The Active Directory object identifier (GUID) */
+  resourceKey: string;
+
+  /** The user's display name */
+  name?: string;
+
+  /** The user's email address */
+  email?: string;
+
+  /** The time at which this record will expire */
+  ttl?: number;
+}
+
+export enum ResourceType {
+  User = 'USER',
 }

--- a/src/dynamo/getDynamoRecords.ts
+++ b/src/dynamo/getDynamoRecords.ts
@@ -1,6 +1,6 @@
 import * as AWS from 'aws-sdk';
 import config from '../config';
-import IDynamoRecord from './IDynamoRecord';
+import IDynamoRecord, { ResourceType } from './IDynamoRecord';
 
 const dynamo = new AWS.DynamoDB.DocumentClient();
 
@@ -10,7 +10,7 @@ export const getDynamoMembers: () => Promise<IDynamoRecord[]> = async () => {
       TableName: config.aws.dynamoTable,
       KeyConditionExpression: 'resourceType = :type',
       ExpressionAttributeValues: {
-        ':type': 'USER',
+        ':type': ResourceType.User,
       },
     } as AWS.DynamoDB.DocumentClient.QueryInput)
     .promise();

--- a/tests/unit/getDynamoRecords.test.ts
+++ b/tests/unit/getDynamoRecords.test.ts
@@ -1,5 +1,6 @@
 import config from '../../src/config';
 import { getDynamoMembers } from '../../src/dynamo/getDynamoRecords';
+import { ResourceType } from '../../src/dynamo/IDynamoRecord';
 
 // has to be 'var' as jest "hoists" execution behind the scenes and let/const cause errors
 /* tslint:disable */
@@ -12,16 +13,16 @@ jest.mock('aws-sdk', () => {
     promise: jest.fn().mockResolvedValue({
       Items: [
         {
-          resourceType: { S: 'USER' },
-          resourceKey: { S: 's@test.com' },
+          resourceType: { S: ResourceType.User },
+          resourceKey: { S: '6adbf131-c6c2-4bc6-b1e9-b62f812bed29' },
           name: { S: 'test user' },
-          staffId: { S: '6adbf131-c6c2-4bc6-b1e9-b62f812bed29' },
+          email: { S: 'testUser@example.com' },
         },
         {
-          resourceType: { S: 'USER' },
-          resourceKey: { S: 's2@test.com' },
+          resourceType: { S: ResourceType.User },
+          resourceKey: { S: '7d9e8e38-78d5-46ad-9fd0-6adad882161b' },
           name: { S: 'test user 2' },
-          staffId: { S: '7d9e8e38-78d5-46ad-9fd0-6adad882161b' },
+          email: { S: 'testUser2@example.com' },
         },
       ],
     } as AWS.DynamoDB.DocumentClient.QueryOutput),
@@ -57,7 +58,7 @@ describe('getDynamoMembers', () => {
       TableName: 'testTable',
       KeyConditionExpression: 'resourceType = :type',
       ExpressionAttributeValues: {
-        ':type': 'USER',
+        ':type': ResourceType.User,
       },
     } as AWS.DynamoDB.DocumentClient.QueryInput);
   });


### PR DESCRIPTION

Improvements ostensibly to fix the synchronisation of more than 100 AAD security group members

- Uses the AAD `id` as our `resourceKey`
- Defaults to requesting the max `999` members from AAD, but can be changed with an environment variable
- Removes duplicate members based on the AAD `id` in case the same member is in multiple groups
- Filters the members to user accounts (default: enabled - this can be toggled off with an environment variable)
- If members aren't filtered to users (above toggle), then the members must have either a `mail` or `userPrincipalName`
- Adds unit tests for all of the above

https://dvsa.atlassian.net/browse/CB2-7861

## Checklist
- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number