### PR TITLE
feat(cb2-8133): stop disabled accounts going into reference data

### DIFF
--- a/src/aad/getMemberDetails.ts
+++ b/src/aad/getMemberDetails.ts
@@ -22,7 +22,7 @@ axios.interceptors.response.use((response) => response, onRejected);
 export const getMemberDetails = async (): Promise<IMemberDetails[]> => {
   const aadBase = config.aad.baseUrl;
   const groupIds = config.aad.groupId.includes(',') ? config.aad.groupId.split(',') : [config.aad.groupId];
-  //const membersToRequest = config.aad.membersToRequest;
+  // const membersToRequest = config.aad.membersToRequest;
 
   const accessToken = await getToken();
 

--- a/src/aad/getMemberDetails.ts
+++ b/src/aad/getMemberDetails.ts
@@ -1,8 +1,8 @@
 import axios, { AxiosError } from 'axios';
 import { URL } from 'url';
+import config from '../config';
 import logger from '../observability/logger';
 import IMemberDetails, { MemberType } from './IMemberDetails';
-import config from '../config';
 import getToken from './getToken';
 
 interface MemberList {
@@ -35,6 +35,7 @@ export const getMemberDetails = async (): Promise<IMemberDetails[]> => {
     axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
 
     const response = await axios.get<MemberList>(requestUrl, { headers: { Authorization: `Bearer ${accessToken}` } });
+    console.log(JSON.stringify(response));
     return response.data.value;
   });
 

--- a/src/aad/getMemberDetails.ts
+++ b/src/aad/getMemberDetails.ts
@@ -28,7 +28,7 @@ export const getMemberDetails = async (): Promise<IMemberDetails[]> => {
 
   const promiseArray = groupIds.map(async (groupId) => {
     const requestUrl = new URL(
-      `/v1.0/groups/${groupId.trim()}/transitivemembers/microsoft.graph.user?$count=true&$filter=accountEnabled eq true`,
+      `/v1.0/groups/${groupId.trim()}/members/microsoft.graph.user?$count=true&$filter=accountEnabled eq true`,
       aadBase,
     ).href;
 

--- a/src/aad/getMemberDetails.ts
+++ b/src/aad/getMemberDetails.ts
@@ -27,16 +27,19 @@ export const getMemberDetails = async (): Promise<IMemberDetails[]> => {
   const accessToken = await getToken();
 
   const promiseArray = groupIds.map(async (groupId) => {
-    const requestUrl = new URL(`/v1.0/groups/${groupId.trim()}/members?$top=${membersToRequest}`, aadBase).href;
+    const requestUrl = new URL(
+      `/v1.0/groups/${groupId.trim()}/transitivemembers/microsoft.graph.user?$count=true&$filter=accountEnabled eq true`,
+      aadBase,
+    ).href;
 
     logger.info(`Trying to get aad member list for group: ${groupId.trim()}`);
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
 
-    console.log(accessToken);
-
-    const response = await axios.get<MemberList>(requestUrl, { headers: { Authorization: `Bearer ${accessToken}` } });
+    const response = await axios.get<MemberList>(requestUrl, {
+      headers: { Authorization: `Bearer ${accessToken}`, ConsistencyLevel: 'eventual' },
+    });
     console.log(response.data.value);
     return response.data.value;
   });

--- a/src/aad/getMemberDetails.ts
+++ b/src/aad/getMemberDetails.ts
@@ -22,7 +22,7 @@ axios.interceptors.response.use((response) => response, onRejected);
 export const getMemberDetails = async (): Promise<IMemberDetails[]> => {
   const aadBase = config.aad.baseUrl;
   const groupIds = config.aad.groupId.includes(',') ? config.aad.groupId.split(',') : [config.aad.groupId];
-  const membersToRequest = config.aad.membersToRequest;
+  //const membersToRequest = config.aad.membersToRequest;
 
   const accessToken = await getToken();
 

--- a/src/aad/getMemberDetails.ts
+++ b/src/aad/getMemberDetails.ts
@@ -28,7 +28,7 @@ export const getMemberDetails = async (): Promise<IMemberDetails[]> => {
 
   const promiseArray = groupIds.map(async (groupId) => {
     const requestUrl = new URL(
-      `/v1.0/groups/${groupId.trim()}/members/microsoft.graph.user?$count=true&$filter=accountEnabled eq true`,
+      `/v1.0/groups/${groupId.trim()}/members?$count=true&$filter=accountEnabled eq true`,
       aadBase,
     ).href;
 

--- a/src/aad/getMemberDetails.ts
+++ b/src/aad/getMemberDetails.ts
@@ -22,7 +22,6 @@ axios.interceptors.response.use((response) => response, onRejected);
 export const getMemberDetails = async (): Promise<IMemberDetails[]> => {
   const aadBase = config.aad.baseUrl;
   const groupIds = config.aad.groupId.includes(',') ? config.aad.groupId.split(',') : [config.aad.groupId];
-  // const membersToRequest = config.aad.membersToRequest;
 
   const accessToken = await getToken();
 
@@ -40,7 +39,6 @@ export const getMemberDetails = async (): Promise<IMemberDetails[]> => {
     const response = await axios.get<MemberList>(requestUrl, {
       headers: { Authorization: `Bearer ${accessToken}`, ConsistencyLevel: 'eventual' },
     });
-    console.log(response.data.value);
     return response.data.value;
   });
 

--- a/src/aad/getMemberDetails.ts
+++ b/src/aad/getMemberDetails.ts
@@ -35,7 +35,7 @@ export const getMemberDetails = async (): Promise<IMemberDetails[]> => {
     axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
 
     const response = await axios.get<MemberList>(requestUrl, { headers: { Authorization: `Bearer ${accessToken}` } });
-    console.log(JSON.stringify(response));
+    console.log(response.data.value);
     return response.data.value;
   });
 

--- a/src/aad/getMemberDetails.ts
+++ b/src/aad/getMemberDetails.ts
@@ -34,6 +34,8 @@ export const getMemberDetails = async (): Promise<IMemberDetails[]> => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
 
+    console.log(accessToken);
+
     const response = await axios.get<MemberList>(requestUrl, { headers: { Authorization: `Bearer ${accessToken}` } });
     console.log(response.data.value);
     return response.data.value;

--- a/tests/unit/getMemberDetails.test.ts
+++ b/tests/unit/getMemberDetails.test.ts
@@ -86,7 +86,7 @@ describe('getMemberDetails', () => {
   it('should get details from the correct url', async () => {
     await getMemberDetails();
     expect(mockAxiosGet).toBeCalledWith(
-      'https://test/v1.0/groups/testGroup/transitivemembers/microsoft.graph.user?$count=true&$filter=accountEnabled%20eq%20true',
+      'https://test/v1.0/groups/testGroup/members/microsoft.graph.user?$count=true&$filter=accountEnabled%20eq%20true',
       {
         headers: { Authorization: 'Bearer testToken', ConsistencyLevel: 'eventual' },
       },
@@ -98,7 +98,7 @@ describe('getMemberDetails', () => {
     await getMemberDetails();
     expect(mockAxiosGet).toBeCalledTimes(6);
     expect(mockAxiosGet).toHaveBeenLastCalledWith(
-      'https://test/v1.0/groups/testGroup6/transitivemembers/microsoft.graph.user?$count=true&$filter=accountEnabled%20eq%20true',
+      'https://test/v1.0/groups/testGroup6/members/microsoft.graph.user?$count=true&$filter=accountEnabled%20eq%20true',
       {
         headers: { Authorization: 'Bearer testToken', ConsistencyLevel: 'eventual' },
       },

--- a/tests/unit/getMemberDetails.test.ts
+++ b/tests/unit/getMemberDetails.test.ts
@@ -1,7 +1,7 @@
 import { Axios, AxiosError, AxiosRequestHeaders } from 'axios';
-import config from '../../src/config';
-import { getMemberDetails } from '../../src/aad/getMemberDetails';
 import IMemberDetails, { MemberType } from '../../src/aad/IMemberDetails';
+import { getMemberDetails } from '../../src/aad/getMemberDetails';
+import config from '../../src/config';
 
 // has to be 'var' as jest "hoists" execution behind the scenes and let/const cause errors
 /* tslint:disable */
@@ -85,18 +85,24 @@ describe('getMemberDetails', () => {
 
   it('should get details from the correct url', async () => {
     await getMemberDetails();
-    expect(mockAxiosGet).toBeCalledWith('https://test/v1.0/groups/testGroup/members?$top=999', {
-      headers: { Authorization: 'Bearer testToken' },
-    });
+    expect(mockAxiosGet).toBeCalledWith(
+      'https://test/v1.0/groups/testGroup/transitivemembers/microsoft.graph.user?$count=true&$filter=accountEnabled%20eq%20true',
+      {
+        headers: { Authorization: 'Bearer testToken', ConsistencyLevel: 'eventual' },
+      },
+    );
   });
 
   it('should get details from the correct urls if multiple groups given', async () => {
     config.aad.groupId = 'testGroup1, testGroup2, testGroup3, testGroup4, testGroup5, testGroup6';
     await getMemberDetails();
     expect(mockAxiosGet).toBeCalledTimes(6);
-    expect(mockAxiosGet).toHaveBeenLastCalledWith('https://test/v1.0/groups/testGroup6/members?$top=999', {
-      headers: { Authorization: 'Bearer testToken' },
-    });
+    expect(mockAxiosGet).toHaveBeenLastCalledWith(
+      'https://test/v1.0/groups/testGroup6/transitivemembers/microsoft.graph.user?$count=true&$filter=accountEnabled%20eq%20true',
+      {
+        headers: { Authorization: 'Bearer testToken', ConsistencyLevel: 'eventual' },
+      },
+    );
   });
 
   it('should return a distinct list of members by id if the same member is in multiple groups', async () => {

--- a/tests/unit/getMemberDetails.test.ts
+++ b/tests/unit/getMemberDetails.test.ts
@@ -86,7 +86,7 @@ describe('getMemberDetails', () => {
   it('should get details from the correct url', async () => {
     await getMemberDetails();
     expect(mockAxiosGet).toBeCalledWith(
-      'https://test/v1.0/groups/testGroup/members/microsoft.graph.user?$count=true&$filter=accountEnabled%20eq%20true',
+      'https://test/v1.0/groups/testGroup/members?$count=true&$filter=accountEnabled%20eq%20true',
       {
         headers: { Authorization: 'Bearer testToken', ConsistencyLevel: 'eventual' },
       },
@@ -98,7 +98,7 @@ describe('getMemberDetails', () => {
     await getMemberDetails();
     expect(mockAxiosGet).toBeCalledTimes(6);
     expect(mockAxiosGet).toHaveBeenLastCalledWith(
-      'https://test/v1.0/groups/testGroup6/members/microsoft.graph.user?$count=true&$filter=accountEnabled%20eq%20true',
+      'https://test/v1.0/groups/testGroup6/members?$count=true&$filter=accountEnabled%20eq%20true',
       {
         headers: { Authorization: 'Bearer testToken', ConsistencyLevel: 'eventual' },
       },


### PR DESCRIPTION
## Ticket title
Update the API call to only get back accounts with accountEnabled set to true
[https://dvsa.atlassian.net/browse/CB2-8133](8133)

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number