### PR TITLE
feat(cb2-11998): repair url call to look at 1000 users page size

### DIFF
--- a/src/aad/getMemberDetails.ts
+++ b/src/aad/getMemberDetails.ts
@@ -27,7 +27,7 @@ export const getMemberDetails = async (): Promise<IMemberDetails[]> => {
 
   const promiseArray = groupIds.map(async (groupId) => {
     const requestUrl = new URL(
-      `/v1.0/groups/${groupId.trim()}/members?$count=true&$filter=accountEnabled eq true`,
+      `/v1.0/groups/${groupId.trim()}/members?$count=true&$top=1000&$filter=accountEnabled eq true`,
       aadBase,
     ).href;
 

--- a/tests/unit/getMemberDetails.test.ts
+++ b/tests/unit/getMemberDetails.test.ts
@@ -86,7 +86,7 @@ describe('getMemberDetails', () => {
   it('should get details from the correct url', async () => {
     await getMemberDetails();
     expect(mockAxiosGet).toBeCalledWith(
-      'https://test/v1.0/groups/testGroup/members?$count=true&$filter=accountEnabled%20eq%20true',
+      'https://test/v1.0/groups/testGroup/members?$count=true&$top=1000&$filter=accountEnabled%20eq%20true',
       {
         headers: { Authorization: 'Bearer testToken', ConsistencyLevel: 'eventual' },
       },
@@ -98,7 +98,7 @@ describe('getMemberDetails', () => {
     await getMemberDetails();
     expect(mockAxiosGet).toBeCalledTimes(6);
     expect(mockAxiosGet).toHaveBeenLastCalledWith(
-      'https://test/v1.0/groups/testGroup6/members?$count=true&$filter=accountEnabled%20eq%20true',
+      'https://test/v1.0/groups/testGroup6/members?$count=true&$top=1000&$filter=accountEnabled%20eq%20true',
       {
         headers: { Authorization: 'Bearer testToken', ConsistencyLevel: 'eventual' },
       },


### PR DESCRIPTION
## Ticket title
AD page size is 100 with a filter, so users are being missed.
[11998](https://dvsa.atlassian.net/browse/CB2-11998)

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number